### PR TITLE
Add `assure` tests for Diabetes Register

### DIFF
--- a/analysis/test_dm_reg_dataset_milan.py
+++ b/analysis/test_dm_reg_dataset_milan.py
@@ -1,0 +1,124 @@
+from datetime import date
+from dm_reg_dataset_milan import dataset
+
+# Patient data for the FY23/24 with index date = "2024-03-31"
+# Run the tests with the following command:
+# opensafely exec ehrql:v1 assure analysis/test_dm_reg_dataset_milan.py
+
+test_data = {
+    # Correctly not expected in population
+    # No clinical events
+    1: {
+        "patients": {"date_of_birth": date(1950, 1, 1)},
+        "practice_registrations": [
+            {
+                "start_date": date(2010, 1, 1),
+            },
+        ],
+        "clinical_events": [{}],
+        "expected_in_population": False,
+    },
+    # Correctly not expected in population
+    # Diagnosis after the index date
+    2: {
+        "patients": {"date_of_birth": date(1950, 1, 1)},
+        "practice_registrations": [
+            {
+                "start_date": date(2010, 1, 1),
+            },
+        ],
+        "clinical_events": [
+            {
+                # First diabetes diagnosis (DM_COD)
+                "date": date(2024, 8, 1),
+                "snomedct_code": "73211009",
+            },
+        ],
+        "expected_in_population": False,
+    },
+    # Correctly not expected in population
+    # Younger than 17yo at index date
+    3: {
+        "patients": {"date_of_birth": date(2010, 1, 1)},
+        "practice_registrations": [
+            {
+                "start_date": date(2010, 1, 1),
+            },
+        ],
+        "clinical_events": [
+            {
+                # First diabetes diagnosis (DM_COD)
+                "date": date(2022, 8, 1),
+                "snomedct_code": "73211009",
+            },
+        ],
+        "expected_in_population": False,
+    },
+    # Correctly not expected in population
+    # Not registered at index date
+    4: {
+        "patients": {"date_of_birth": date(1960, 1, 1)},
+        "practice_registrations": [
+            {
+                "start_date": date(1960, 1, 1),
+                "end_date": date(2020, 1, 1),
+            },
+        ],
+        "clinical_events": [
+            {
+                # First diabetes diagnosis (DM_COD)
+                "date": date(2022, 8, 1),
+                "snomedct_code": "73211009",
+            },
+        ],
+        "expected_in_population": False,
+    },
+    # Correctly not expected in population
+    # Diabetes diagnosis resolved before index date
+    5: {
+        "patients": {"date_of_birth": date(1960, 1, 1)},
+        "practice_registrations": [
+            {
+                "start_date": date(1960, 1, 1),
+            },
+        ],
+        "clinical_events": [
+            {
+                # First diabetes diagnosis (DM_COD)
+                "date": date(2000, 6, 1),
+                "snomedct_code": "73211009",
+            },
+            {
+                # Diabetes diagnosis resolved (DMRES_COD)
+                "date": date(2023, 1, 1),
+                "snomedct_code": "315051004",
+            },
+        ],
+        "expected_in_population": False,
+    },
+    # Correctly expected in population
+    # Diabetes diagnosis resolved before index date
+    6: {
+        "patients": {"date_of_birth": date(1960, 1, 1)},
+        "practice_registrations": [
+            {
+                "start_date": date(1960, 1, 1),
+            },
+        ],
+        "clinical_events": [
+            {
+                # First diabetes diagnosis (DM_COD)
+                "date": date(2000, 6, 1),
+                "snomedct_code": "73211009",
+            },
+        ],
+        "expected_in_population": True,
+        "expected_columns": {
+            "pat_age": 64,
+            "dmlat_dat": date(2000, 6, 1),
+            "dmres_dat": None,
+            "dm_reg_r1": True,
+            "dm_reg_r2": False,
+        },
+    },
+}

--- a/analysis/test_dm_reg_dataset_milan.py
+++ b/analysis/test_dm_reg_dataset_milan.py
@@ -121,20 +121,22 @@ test_data = {
             "dm_reg_r2": False,
         },
     },
-       7: {
-              "patients": {"date_of_birth": date(1960, 1, 1)},
-              "practice_registrations": [
-                  {
-                      "start_date": date(1960, 1, 1),
-                  },
-              ],
-              "clinical_events": [
-                  {
-                      # First diabetes diagnosis (DM_COD)
-                      "date": date(2000, 6, 1),
-                      "snomedct_code": "82272006",
-                  },
-              ],
-              "expected_in_population": False,
-          },
+    # Correctly not expected in population
+    # Code not form DM_COD codelist
+    7: {
+        "patients": {"date_of_birth": date(1960, 1, 1)},
+        "practice_registrations": [
+            {
+                "start_date": date(1960, 1, 1),
+            },
+        ],
+        "clinical_events": [
+            {
+                # Code not in the codelist
+                "date": date(2000, 6, 1),
+                "snomedct_code": "1111111111",
+            },
+        ],
+        "expected_in_population": False,
+    },
 }

--- a/analysis/test_dm_reg_dataset_milan.py
+++ b/analysis/test_dm_reg_dataset_milan.py
@@ -121,4 +121,20 @@ test_data = {
             "dm_reg_r2": False,
         },
     },
+       7: {
+              "patients": {"date_of_birth": date(1960, 1, 1)},
+              "practice_registrations": [
+                  {
+                      "start_date": date(1960, 1, 1),
+                  },
+              ],
+              "clinical_events": [
+                  {
+                      # First diabetes diagnosis (DM_COD)
+                      "date": date(2000, 6, 1),
+                      "snomedct_code": "82272006",
+                  },
+              ],
+              "expected_in_population": False,
+          },
 }

--- a/project.yaml
+++ b/project.yaml
@@ -15,6 +15,7 @@ actions:
     run: >
       ehrql:v1 
         generate-dataset analysis/dm_reg_dataset_milan.py
+        --test-data-file analysis/test_dm_reg_dataset_milan.py
         --output output/dm/dm017_milan.csv.gz
     outputs:
       highly_sensitive:


### PR DESCRIPTION
This is the exampple solution for #10.

Patients 1 to 4 test different exclusion rules.
Patient 5 is correctly expected in the population with expected column values.